### PR TITLE
Wypis Hatim_Matoga [lil matoga]

### DIFF
--- a/docs/czarna-lista.md
+++ b/docs/czarna-lista.md
@@ -19,4 +19,3 @@ Osoby z listy ostatniej szansy przy otrzymaniu bana z tym samym powodem (lub dow
 | 2019-05-06 | Pascual_Grande | [Paskal](https://mrucznik-rp.pl/user/13586-paskal/) |
 | 2019-05-07 | Seiko_Hanari | [011](https://mrucznik-rp.pl/user/8216-011/) |
 | 2019-06-08 | Patrick_Migle | [migiell](https://mrucznik-rp.pl/user/13646-migiell/) |
-| 2019-06-23 | Hatim_Matoga | [lil matoga](https://mrucznik-rp.pl/user/13854-lil-matoga/) |


### PR DESCRIPTION
- Wypis Hatim_Matoga [lil matoga] z powodu błędnej weryfikacji 'obecności' tego gracza na liście ostatniej szansy, dodatkowo wpis na listę ostatniej szansy na kolejne 6 miesięcy (do końca XII - 2019 r. )