### PR TITLE
Update czarna-lista.md

### DIFF
--- a/docs/czarna-lista.md
+++ b/docs/czarna-lista.md
@@ -21,3 +21,4 @@ Osoby z listy ostatniej szansy przy otrzymaniu bana z tym samym powodem (lub dow
 | 2019-06-08 | Patrick_Migle | [migiell](https://mrucznik-rp.pl/user/13646-migiell/) |
 | 2019-06-27 | Jack_Winslet | [neq](https://mrucznik-rp.pl/user/3514-neq/) |
 | 2019-07-24 | Mikolai_Maciaszek | [miszor](https://mrucznik-rp.pl/user/6835-miszor/) |
+| 2019-09-01 | Paul_Brain/Witold_Mopsak/Artyom_Kurylowitz/Tom_Betoniarka | [rapppa](https://mrucznik-rp.pl/user/15814-rapppa/) |


### PR DESCRIPTION
Dodanie do czarnej listy:
| 2019-09-01 | Paul_Brain/Witold_Mopsak/Artyom_Kurylowitz/Tom_Betoniarka | [rapppa](https://mrucznik-rp.pl/user/15814-rapppa/) |
Za 7 warnów tylko na 3 znanych nam kontach podczas listy ostatniej szansy za łamanie LKIZ! Dodatkowo konto Tom_Betoniarka, które zostało zbanowane za ekstremalny DM i BE, podczas listy ostatniej szansy!