### PR TITLE
Dodanie na czarną listę.

### DIFF
--- a/docs/czarna-lista.md
+++ b/docs/czarna-lista.md
@@ -23,3 +23,4 @@ Osoby z listy ostatniej szansy przy otrzymaniu bana z tym samym powodem (lub dow
 | 2019-07-24 | Mikolai_Maciaszek | [miszor](https://mrucznik-rp.pl/user/6835-miszor/) |
 | 2019-08-08 | Lewis_Shane | [młody okrutnik](https://mrucznik-rp.pl/user/15960-m%C5%82ody-okrutnik/) | 
 | 2019-09-01 | Paul_Brain/Witold_Mopsak/Artyom_Kurylowitz/Tom_Betoniarka | [rapppa](https://mrucznik-rp.pl/user/15814-rapppa/) |
+| 2019-09-13 | Hatim_Matoga | [lil matoga](https://mrucznik-rp.pl/user/13854-lil-matoga/) |


### PR DESCRIPTION
| 2019-09-13 | Hatim_Matoga | [lil matoga](https://mrucznik-rp.pl/user/13854-lil-matoga/) |
Line 11054: [2019/03/01 - 16:09:23] AdmCmd: Admin Orlando_Hamilton zbanowal Hatim_Matoga, powód: speedhack